### PR TITLE
support omitempty for nil pointers

### DIFF
--- a/response.go
+++ b/response.go
@@ -248,14 +248,22 @@ func visitModelNode(model interface{}, included *map[string]*Node, sideload bool
 					node.Attributes[args[1]] = tm.Unix()
 				}
 			} else {
-				strAttr, ok := fieldValue.Interface().(string)
+				if fieldValue.Kind() == reflect.Ptr && fieldValue.IsNil() {
+					if omitEmpty {
+						continue
+					}
 
-				if ok && strAttr == "" && omitEmpty {
-					continue
-				} else if ok {
-					node.Attributes[args[1]] = strAttr
+					node.Attributes[args[1]] = nil
 				} else {
-					node.Attributes[args[1]] = fieldValue.Interface()
+					strAttr, ok := fieldValue.Interface().(string)
+
+					if ok && strAttr == "" && omitEmpty {
+						continue
+					} else if ok {
+						node.Attributes[args[1]] = strAttr
+					} else {
+						node.Attributes[args[1]] = fieldValue.Interface()
+					}
 				}
 			}
 		} else if annotation == "relation" {

--- a/response_test.go
+++ b/response_test.go
@@ -35,6 +35,7 @@ type Comment struct {
 	ClientId string `jsonapi:"client-id"`
 	PostId   int    `jsonapi:"attr,post_id"`
 	Body     string `jsonapi:"attr,body"`
+	Reviewed *bool  `jsonapi:"attr,reviewed,omitempty"`
 }
 
 func TestHasPrimaryAnnotation(t *testing.T) {
@@ -364,5 +365,30 @@ func TestGoodLinks(t *testing.T) {
 	}
 	if link != "link_1" {
 		t.Fatalf("Link value is not correct: %s", link)
+	}
+}
+
+func TestNilPointerOmitEmpty(t *testing.T) {
+	c := Comment{Id: 42, PostId: 69, Body: "body"}
+	data, err := MarshalOne(&c)
+	if err != nil {
+		t.Fatalf("Error marshaling: %+v", err)
+	}
+
+	_, ok := data.Data.Attributes["reviewed"]
+	if ok {
+		t.Fatal("Expected to NOT find a reviewed property")
+	}
+
+	b := false
+	c.Reviewed = &b
+	data, err = MarshalOne(&c)
+	if err != nil {
+		t.Fatalf("Error marshaling: %+v", err)
+	}
+
+	_, ok = data.Data.Attributes["reviewed"]
+	if !ok {
+		t.Fatalf("Expected to find a reviewed property on %+v", c)
 	}
 }


### PR DESCRIPTION
This change will allow for using 'omitempty' on a pointer so the value in the marshaled json is not "null".
